### PR TITLE
Add Socks5 and HTTP Proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,17 @@ RUN set -ex && \
     libxkbcommon-dev \
     libxkbcommon-x11-dev \
     libnss3 iptables xclip libxtst6 \
-    busybox libssl-dev iproute2 simpleproxy libxss1 ca-certificates && \
+    busybox libssl-dev iproute2 libxss1 ca-certificates \
+    wget && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+# Download and install gost
+RUN wget https://github.com/ginuerzh/gost/releases/download/v2.11.1/gost-linux-amd64-2.11.1.gz && \
+    gunzip gost-linux-amd64-2.11.1.gz && \
+    mv gost-linux-amd64-2.11.1 /usr/local/bin/gost && \
+    chmod +x /usr/local/bin/gost && \
+    rm -f gost-linux-amd64-2.11.1.gz
 
 # Setup demo environment variables
 ENV HOME=/root \
@@ -57,6 +65,8 @@ COPY root /root
 
 EXPOSE 8080
 EXPOSE 2222
+EXPOSE 10801
+EXPOSE 18888
 
 COPY app /app
 CMD ["/app/entrypoint.sh"]

--- a/app/conf.d/gost.conf
+++ b/app/conf.d/gost.conf
@@ -1,0 +1,3 @@
+[program:gost]
+command=/usr/local/bin/gost -L socks5://:10801 -L tcp://:2222/%(ENV_REMOTE_HOST)s:2222 -L http://:18888
+autorestart=true

--- a/app/conf.d/simpleproxy.conf
+++ b/app/conf.d/simpleproxy.conf
@@ -1,3 +1,0 @@
-[program:simpleproxy]
-command=simpleproxy -L 0.0.0.0:2222 -R "%(ENV_REMOTE_HOST)s"
-autorestart=true


### PR DESCRIPTION
This PR adds support for Socks5 and HTTP proxies in our application. Users can now configure and use both proxy types for network requests, enhancing flexibility and functionality.